### PR TITLE
Derive PartialEq/Eq for HID Report structures.

### DIFF
--- a/hidparser/src/lib.rs
+++ b/hidparser/src/lib.rs
@@ -207,7 +207,7 @@ fn field_range(min: LogicalMinimum, max: LogicalMaximum) -> Option<u32> {
 }
 
 /// Describes a report collection.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ReportCollection {
   /// The usage associated with the collection.
   pub usage: Usage,
@@ -220,7 +220,7 @@ pub struct ReportCollection {
 }
 
 /// Describes a Variable data field in a report descriptor.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct VariableField {
   /// The bit range that the variable data field occupies in the report.
   pub bits: Range<u32>,
@@ -276,7 +276,7 @@ impl VariableField {
 }
 
 /// Describes an Array data field in a report descriptor.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct ArrayField {
   /// The bit range that the array data field occupies in the report.
   pub bits: Range<u32>,
@@ -314,14 +314,14 @@ impl ArrayField {
 }
 
 /// Describes a Padding data field in a report descriptor (i.e. a field without usages).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PaddingField {
   /// The bit range that the padding data field occupies in the report.
   pub bits: Range<u32>,
 }
 
 /// Defines the types of fields that appear in a report.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReportField {
   Variable(VariableField),
   Array(ArrayField),
@@ -329,7 +329,7 @@ pub enum ReportField {
 }
 
 /// Describes a report.
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Report {
   /// The (optional) report id associated with the report.
   pub report_id: Option<ReportId>,
@@ -340,6 +340,7 @@ pub struct Report {
 }
 
 /// A collection of input/output/feature reports that are described by a given Report Descriptor.
+#[derive(Debug, PartialEq, Eq)]
 pub struct ReportDescriptor {
   /// The list of input reports from this report descriptor.
   pub input_reports: Vec<Report>,

--- a/hidparser/src/report_data_types.rs
+++ b/hidparser/src/report_data_types.rs
@@ -271,7 +271,7 @@ impl From<u32> for DesignatorIndex {
 }
 
 /// Represents a range of indices in the Physical descriptor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DesignatorRange(RangeInclusive<u32>);
 impl DesignatorRange {
   pub fn start(&self) -> u32 {
@@ -297,7 +297,7 @@ impl From<u32> for StringIndex {
 }
 
 /// Represents an range of indices in the String descriptor.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StringRange(RangeInclusive<u32>);
 impl StringRange {
   pub fn start(&self) -> u32 {

--- a/hidparser/src/report_descriptor_parser.rs
+++ b/hidparser/src/report_descriptor_parser.rs
@@ -1391,4 +1391,12 @@ mod tests {
       Some(ReportDescriptorError::InvalidReportLogicalRange)
     );
   }
+
+  #[test]
+  fn report_descriptors_parsed_from_same_buffer_should_be_equal() {
+    assert_eq!(
+      ReportDescriptorParser::parse(MINIMAL_BOOT_KEYBOARD_REPORT_DESCRIPTOR),
+      ReportDescriptorParser::parse(MINIMAL_BOOT_KEYBOARD_REPORT_DESCRIPTOR)
+    );
+  }
 }


### PR DESCRIPTION
## Description

Derives implementations of PartialEq/Eq traits for HID report descriptor structures. 

- [x] Impacts functionality?
  - Adds PartialEq/Eq implementations for report descriptor structures.
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

PR includes a unit test that parses a report descriptor twice and verifies the results are equal.

## Integration Instructions
N/A
