### PR TITLE
Refine report parsing to allow a non-spec compliant report to be handled without aborting processing of the whole descriptor.

### DIFF
--- a/examples/hidparse.rs
+++ b/examples/hidparse.rs
@@ -96,8 +96,29 @@ fn main() -> Result<(), Box<dyn Error>> {
   let args = Arguments::parse();
   let raw_descriptor = fs::read(args.path)?;
 
-  let ReportDescriptor { input_reports, output_reports, features } =
+  let ReportDescriptor { input_reports, bad_input_reports, output_reports, bad_output_reports, features, bad_features } =
     parse_report_descriptor(&raw_descriptor).map_err(|_| "Failed to parse descriptor.")?;
+
+  if !bad_input_reports.is_empty() {
+    println!("Bad input reports:");
+    for bad_report in bad_input_reports {
+      println!("{:x?}", bad_report);
+    }
+  }
+
+  if !bad_output_reports.is_empty() {
+    println!("Bad output reports:");
+    for bad_report in bad_output_reports {
+      println!("{:x?}", bad_report);
+    }
+  }
+
+  if !bad_features.is_empty() {
+    println!("Bad feature reports:");
+    for bad_report in bad_features {
+      println!("{:x?}", bad_report);
+    }
+  }
 
   let reports = (iter::repeat(ReportType::Input).zip(input_reports))
     .chain(iter::repeat(ReportType::Output).zip(output_reports))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -351,10 +351,16 @@ pub struct Report {
 pub struct ReportDescriptor {
   /// The list of input reports from this report descriptor.
   pub input_reports: Vec<Report>,
+  /// The list of input reports (if any) that failed to parse.
+  pub bad_input_reports: Vec<(Option<ReportId>, ReportDescriptorError)>,
   /// The list of output reports from this report descriptor.
   pub output_reports: Vec<Report>,
+  /// The list of output reports (if any) that failed to parse.
+  pub bad_output_reports: Vec<(Option<ReportId>, ReportDescriptorError)>,
   /// The list of feature reports from this report descriptor.
   pub features: Vec<Report>,
+  /// The list of feature reports (if any) that failed to parse.
+  pub bad_features: Vec<(Option<ReportId>, ReportDescriptorError)>,
 }
 
 /// Parse the raw report descriptor in the given byte slice.


### PR DESCRIPTION
Refine report parsing to allow a non-spec compliant report to be handled without aborting processing of the whole descriptor.

## Description

This allows handling descriptors that are not completely per HID spec; this allows partial support for devices where some reports are not valid, but some are. This gives more flexibility in supporting hardware with various degrees of adherence to spec requirements. 

- [x] Impacts functionality?
  - If an error is detected in a report descriptor, only the affected reports are not parsed. Other reports that are valid within the same descriptor are still parsed and returned. Parsing returns a list of any errors determined along with the ids (if any) of the affected reports. 
- [ ] Impacts security?
- [x] Breaking change?
  - The main parsing API (`ReportDescriptor::parse(&[u8]) -> Result<ReportDescriptor, ReportDescriptorError> does not change, but the definition of ReportDescriptor expands to include "bad descriptor" lists to report parsing failures, and error is no longer returned for the whole descriptor for all errors. Invalid item tokenization will still cause the whole descriptor parse to fail, but if an error is localized (like missing report count), then the remaining unaffected reports are returned. 
- [x] Includes tests?
  - Tests and examples updated to accommodate the change.
- [ ] Includes documentation?

## How This Was Tested

Unit tests updated and passed, example parser behavior verified on good and bad descriptors.

## Integration Instructions
N/A unless the application was previously relying on descriptor parse failure semantics in some way, in which case error cases may need to be revisited. 