### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Repo File Sync: .sync/rust_config/rustfmt.toml: Use Rust default of 4 space indentation
+d8f0b8a9866092a31c76d5f17b3054d5825ba986


### PR DESCRIPTION
## Description

This file should only be used to ignore changes that are completely non-functional.

In this case, it is ignoring the commit that updated from 2 to 4 spaces.

- [ ] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

**Before:**

`> git blame -L 18,18 src\report_data_types.rs`

```
d8f0b8a9 (Project Mu UEFI Bot [bot] 2024-07-22 16:07:38 -0400 18)     fn from(bytes: &[u8]) -> Self {
```

**After:**

`> git blame --ignore-revs-file .git-blame-ignore-revs -L 18,18 src\report_data_types.rs`

```
59d75fc4 hidparser/src/report_data_types.rs (John Schock 2023-09-25 12:59:05 -0700 18)     fn from(bytes: &[u8]) -> Self {
```

## Integration Instructions

Set up your git config to you the ignore file if it is not already globally set to use files with the `.git-blame-ignore-revs` naming convention.