### PR TITLE
Optionally associate reports with usages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,8 @@ pub enum ReportField {
 pub struct Report {
     /// The (optional) report id associated with the report.
     pub report_id: Option<ReportId>,
+    /// The (optional) usage id associated with the report.
+    pub usage: Option<Usage>,
     /// The size in bits of the report.
     pub size_in_bits: usize,
     /// The list of fields in the report.

--- a/src/report_descriptor_parser.rs
+++ b/src/report_descriptor_parser.rs
@@ -455,7 +455,9 @@ impl ReportDescriptorParser {
                 }
             }
 
-            reports.push(Report { report_id: *id, size_in_bits: bit_position as usize, fields });
+            let usage = report_data.first().and_then(|d| d.member_of.get(1)).map(|c| c.usage);
+
+            reports.push(Report { report_id: *id, usage, size_in_bits: bit_position as usize, fields });
         }
 
         (reports, bad_reports)


### PR DESCRIPTION
Add support for parsing usages into the
report structure, which can be useful
for certain HID devices, e.g. if they
support LampArray functionality.

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [ ] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

I tested this with Microsoft RP2040MacropadHidSample on a suitable device: https://github.com/microsoft/RP2040MacropadHidSample

## Integration Instructions

N/A
