### PR TITLE
Remediate several sources of panic on malformed report descriptor data.

### DIFF
--- a/src/item_tokenizer.rs
+++ b/src/item_tokenizer.rs
@@ -27,30 +27,35 @@ pub struct ReportItem<'a> {
     pub data: &'a [u8],
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DescriptorItemTokenizerError {
+    pub(crate) item_type: ReportItemType,
+}
+
 /// Item tokenizer - produces an iterator over a byte slice that returns ReportItems.
-pub struct DescriptorItemTokenizer<'a> {
+pub(crate) struct DescriptorItemTokenizer<'a> {
     descriptor: &'a [u8],
     position: usize,
 }
 
 impl<'a> DescriptorItemTokenizer<'a> {
     /// Instantiates a new HID Report Descriptor Item Tokenizer.
-    pub fn new(descriptor: &'a [u8]) -> Self {
+    pub(crate) fn new(descriptor: &'a [u8]) -> Self {
         DescriptorItemTokenizer { descriptor, position: 0 }
     }
 }
 
 impl<'a> Iterator for DescriptorItemTokenizer<'a> {
-    type Item = ReportItem<'a>;
+    type Item = Result<ReportItem<'a>, DescriptorItemTokenizerError>;
     fn next(&mut self) -> Option<Self::Item> {
-        let item_header = self.descriptor.get(self.position)?;
+        let item_header = *self.descriptor.get(self.position)?;
         let mut size = item_header & 0x3;
         let item_type = match (item_header & 0xC) >> 2 {
             0 => ReportItemType::Main,
             1 => ReportItemType::Global,
             2 => ReportItemType::Local,
             3 => ReportItemType::Reserved,
-            _ => unreachable!(),
+            _ => ReportItemType::Reserved,
         };
         let mut tag = (item_header & 0xF0) >> 4;
 
@@ -63,17 +68,42 @@ impl<'a> Iterator for DescriptorItemTokenizer<'a> {
 
         if (size == 2) && (tag == 0xF) && (item_type) == ReportItemType::Reserved {
             // long item type
-            size = *self.descriptor.get(self.position)?;
+            size = match self.descriptor.get(self.position) {
+                Some(size) => *size,
+                None => {
+                    self.position = self.descriptor.len();
+                    return Some(Err(DescriptorItemTokenizerError { item_type }));
+                }
+            };
             self.position += 1;
-            tag = *self.descriptor.get(self.position)?;
+            tag = match self.descriptor.get(self.position) {
+                Some(tag) => *tag,
+                None => {
+                    self.position = self.descriptor.len();
+                    return Some(Err(DescriptorItemTokenizerError { item_type }));
+                }
+            };
             self.position += 1;
         }
 
-        let data = self.descriptor.get(self.position..self.position + size as usize)?;
+        let data_end = match self.position.checked_add(size as usize) {
+            Some(data_end) => data_end,
+            None => {
+                self.position = self.descriptor.len();
+                return Some(Err(DescriptorItemTokenizerError { item_type }));
+            }
+        };
+        let data = match self.descriptor.get(self.position..data_end) {
+            Some(data) => data,
+            None => {
+                self.position = self.descriptor.len();
+                return Some(Err(DescriptorItemTokenizerError { item_type }));
+            }
+        };
 
-        self.position += size as usize;
+        self.position = data_end;
 
-        Some(ReportItem { item_type, tag, data })
+        Some(Ok(ReportItem { item_type, tag, data }))
     }
 }
 
@@ -198,12 +228,28 @@ mod tests {
     fn item_tokenizer_should_tokenize_items() {
         let tokenizer = DescriptorItemTokenizer::new(TEST_REPORT_DESCRIPTOR);
 
-        let items: Vec<_> = tokenizer.collect();
+        let items: Result<Vec<_>, _> = tokenizer.collect();
+        let items = items.unwrap();
 
         assert_eq!(items.len(), EXPECTED_ITEMS.len(), "tokenizer did not produce the correct number of items");
 
         for (index, (item, expected_item)) in items.iter().zip(EXPECTED_ITEMS.iter()).enumerate() {
             assert_eq!(item, expected_item, "invalid tokenization of item at index {index:?}");
+        }
+    }
+
+    #[test]
+    fn item_tokenizer_should_reject_truncated_items() {
+        for (descriptor, item_type) in [
+            (&[0x02, 0x01][..], ReportItemType::Main),
+            (&[0x06, 0x01][..], ReportItemType::Global),
+            (&[0x0a, 0x01][..], ReportItemType::Local),
+            (&[0xfe][..], ReportItemType::Reserved),
+            (&[0xfe, 0x01][..], ReportItemType::Reserved),
+            (&[0xfe, 0x01, 0x00][..], ReportItemType::Reserved),
+        ] {
+            let error = DescriptorItemTokenizer::new(descriptor).next().unwrap().unwrap_err();
+            assert_eq!(error.item_type, item_type);
         }
     }
 }

--- a/src/report_descriptor_parser.rs
+++ b/src/report_descriptor_parser.rs
@@ -183,7 +183,12 @@ impl ReportDescriptorParser {
     // handles parsing for "global" items
     fn parse_global(&mut self, item: ReportItem) -> Result<(), ReportDescriptorError> {
         match item.tag {
-            0b0000 => self.global_state[0].usage_page = Some(UsagePage::from(item.data)),
+            0b0000 => {
+                if item.data.len() > 2 {
+                    return Err(ReportDescriptorError::InvalidGlobalItem);
+                }
+                self.global_state[0].usage_page = Some(UsagePage::from(item.data));
+            }
             0b0001 => self.global_state[0].logical_minimum = Some(LogicalMinimum::from(item.data)),
             0b0010 => self.global_state[0].logical_maximum = Some(LogicalMaximum::from(item.data)),
             0b0011 => self.global_state[0].physical_minimum = Some(PhysicalMinimum::from(item.data)),
@@ -409,8 +414,8 @@ impl ReportDescriptorParser {
                         };
                         fields.push(ReportField::Variable(field));
 
-                        if usage_iterator.peek().is_some() {
-                            usage = usage_iterator.next().unwrap();
+                        if let Some(next_usage) = usage_iterator.next() {
+                            usage = next_usage;
                         }
                         if designator_iterator.peek().is_some() {
                             designator = designator_iterator.next();
@@ -467,6 +472,12 @@ impl ReportDescriptorParser {
         let item_tokenizer = DescriptorItemTokenizer::new(report_descriptor);
         let mut parser = Self::new();
         for item in item_tokenizer {
+            let item = item.map_err(|error| match error.item_type {
+                ReportItemType::Main => ReportDescriptorError::InvalidMainItem,
+                ReportItemType::Global => ReportDescriptorError::InvalidGlobalItem,
+                ReportItemType::Local => ReportDescriptorError::InvalidLocalItem,
+                ReportItemType::Reserved => ReportDescriptorError::ReservedItemNotSupported,
+            })?;
             parser.parse_item(item)?;
         }
 
@@ -1420,6 +1431,18 @@ mod tests {
             ReportDescriptorParser::parse(BOGUS_BOOT_KEYBOARD_REPORT_DESCRIPTOR_DELIMITER).err(),
             Some(ReportDescriptorError::DelimiterNotSupported,)
         );
+
+        for (descriptor, error) in [
+            (&[0x02, 0x01][..], ReportDescriptorError::InvalidMainItem),
+            (&[0x06, 0x01][..], ReportDescriptorError::InvalidGlobalItem),
+            (&[0x0a, 0x01][..], ReportDescriptorError::InvalidLocalItem),
+            (&[0xfe][..], ReportDescriptorError::ReservedItemNotSupported),
+            (&[0xfe, 0x01][..], ReportDescriptorError::ReservedItemNotSupported),
+            (&[0xfe, 0x01, 0x00][..], ReportDescriptorError::ReservedItemNotSupported),
+            (&[0x07, 0x00, 0x00, 0x00, 0x00][..], ReportDescriptorError::InvalidGlobalItem),
+        ] {
+            assert_eq!(ReportDescriptorParser::parse(descriptor).unwrap_err(), error);
+        }
 
         let ReportDescriptor { mut bad_input_reports, .. } =
             ReportDescriptorParser::parse(BOGUS_BOOT_KEYBOARD_REPORT_DESCRIPTOR_NO_REPORT_SIZE).unwrap();

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -32,7 +32,7 @@ pub fn i32_from_bytes(bytes: &[u8]) -> i32 {
     }
     let mut i32_bytes = [0_u8; 4];
     //sign-extend
-    if (bytes.last().unwrap() & 0x80) != 0 {
+    if bytes.last().is_some_and(|byte| byte & 0x80 != 0) {
         i32_bytes.fill(0xff);
     }
     i32_bytes[..bytes.len()].clone_from_slice(bytes);


### PR DESCRIPTION
## Description

In the face of certain types of malformed report descriptor data, the parser can panic instead of returning errors. This change converts several sources of panic to return error instead. Care is taken to retain the existing API; panic'ing errors are returned using existing error enumerations. 

- [x] Impacts functionality?
- [ ] Impacts security?
- [ ] Breaking change?
- [x] Includes tests?
- [ ] Includes documentation?

## How This Was Tested

Passes existing unit tests and new focused testing. Tested on live hardware with malformed descriptors that used to panic, and no longer observe those panics. Tested existing well-formed descriptors on live hardware and confirmed existing correct operation unaffected.

## Integration Instructions

N/A